### PR TITLE
Add draft endpoints with League and Draft resource objects

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:docs.sleeper.com)",
+      "Bash(bundle exec rspec spec/sleeper_ff/client/leagues_spec.rb 2>&1)",
+      "Bash(chmod +x /Users/jm/code/sleeper_ff/.git/hooks/commit-msg)",
+      "Bash(bundle exec rspec spec/sleeper_ff/client/drafts_spec.rb spec/sleeper_ff/client/leagues_spec.rb 2>&1)",
+      "Bash(bundle exec rspec 2>&1)",
+      "Bash(git add \\\\\n  README.md \\\\\n  lib/sleeper_ff/client.rb \\\\\n  lib/sleeper_ff/client/leagues.rb \\\\\n  lib/sleeper_ff/client/drafts.rb \\\\\n  lib/sleeper_ff/draft.rb \\\\\n  lib/sleeper_ff/league.rb \\\\\n  spec/sleeper_ff/client/leagues_spec.rb \\\\\n  spec/sleeper_ff/client/drafts_spec.rb \\\\\n  spec/fixtures/vcr_cassettes/SleeperFF_Client_Drafts/ \\\\\n  spec/fixtures/vcr_cassettes/SleeperFF_Client_Leagues/_league_drafts/ \\\\\n  .claude/ && \\\\\ngit commit -m \"$\\(cat <<'EOF'\nAdd draft endpoints with League and Draft resource objects\n\nImplements all Sleeper draft API endpoints:\n- GET /user/:id/drafts/nfl/:season via client.user_drafts\n- GET /draft/:id via client.draft\n- GET /draft/:id/picks via client.draft_picks / draft.picks\n- GET /draft/:id/traded_picks via client.draft_traded_picks / draft.traded_picks\n- GET /league/:id/drafts via client.league_drafts / league.drafts\n\nIntroduces SleeperFF::League and SleeperFF::Draft resource classes that\nwrap raw API data and expose lazy association methods \\(e.g. league.drafts,\ndraft.picks\\) without additional HTTP calls until accessed.\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n\\)\")"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ rosters = client.league_rosters("league_id")
 
 # Get all users in a league
 users = client.league_users("league_id")
+
+# Get all drafts for a league
+drafts = client.league_drafts("league_id")
+# or via the league object
+drafts = league.drafts
 ```
 
 You can access various attributes on the returned objects:
@@ -97,9 +102,55 @@ roster.starters      # => ["player_id1", "player_id2", ...]
 roster.settings      # => { wins: 10, losses: 4, ... }
 ```
 
+### Drafts
+
+```ruby
+# Get all drafts for a user in a season
+drafts = client.user_drafts("user_id", 2023)
+
+# Get a specific draft
+draft = client.draft("draft_id")
+
+# Get all picks in a draft
+picks = client.draft_picks("draft_id")
+# or via the draft object
+picks = draft.picks
+
+# Get all traded picks in a draft
+traded_picks = client.draft_traded_picks("draft_id")
+# or via the draft object
+traded_picks = draft.traded_picks
+```
+
+You can access various attributes on draft objects:
+
+```ruby
+# Draft attributes
+draft.draft_id    # => "917001170459361281"
+draft.league_id   # => "917001170459361280"
+draft.type        # => "snake"
+draft.status      # => "complete"
+draft.season      # => "2023"
+draft.settings    # => { teams: 12, rounds: 15, ... }
+draft.draft_order # => { "user_id" => slot, ... }
+
+# Pick attributes
+pick.player_id    # => "4046"
+pick.picked_by    # => "user_id"
+pick.round        # => 1
+pick.pick_no      # => 1
+pick.metadata     # => { first_name: "Kareem", last_name: "Hunt", ... }
+
+# Traded pick attributes
+traded_pick.season            # => "2023"
+traded_pick.round             # => 3
+traded_pick.roster_id         # => 1
+traded_pick.previous_owner_id # => 3
+traded_pick.owner_id          # => 5
+```
+
 More endpoints coming soon:
 - Players
-- Drafts
 - Matchups
 - Transactions
 

--- a/lib/sleeper_ff/client.rb
+++ b/lib/sleeper_ff/client.rb
@@ -4,6 +4,7 @@ require "sawyer"
 require "sleeper_ff/configurable"
 require "sleeper_ff/client/users"
 require "sleeper_ff/client/leagues"
+require "sleeper_ff/client/drafts"
 require "sleeper_ff/client/players"
 
 module SleeperFF
@@ -11,6 +12,7 @@ module SleeperFF
     include SleeperFF::Configurable
     include SleeperFF::Client::Users
     include SleeperFF::Client::Leagues
+    include SleeperFF::Client::Drafts
     include SleeperFF::Client::Players
 
     # Header keys that can be passed in options hash

--- a/lib/sleeper_ff/client/drafts.rb
+++ b/lib/sleeper_ff/client/drafts.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "sleeper_ff/draft"
+
+module SleeperFF
+  class Client
+    module Drafts
+      # Get all drafts for a user in a season
+      #
+      # @param user_id [String] User ID
+      # @param season [Integer] NFL season year (e.g., 2023)
+      # @return [Array<SleeperFF::Draft>] Array of draft objects
+      def user_drafts(user_id, season)
+        data = get "user/#{user_id}/drafts/nfl/#{season}"
+        return [] if data.nil?
+
+        data.map { |d| SleeperFF::Draft.new(d, self) }
+      end
+
+      # Get a specific draft
+      #
+      # @param draft_id [String] Draft ID
+      # @return [SleeperFF::Draft] Draft object
+      def draft(draft_id)
+        data = get "draft/#{draft_id}"
+        return nil if data.nil?
+
+        SleeperFF::Draft.new(data, self)
+      end
+
+      # Get all picks in a draft
+      #
+      # @param draft_id [String] Draft ID
+      # @return [Array<Sawyer::Resource>] Array of pick objects
+      def draft_picks(draft_id)
+        get "draft/#{draft_id}/picks"
+      end
+
+      # Get all traded picks in a draft
+      #
+      # @param draft_id [String] Draft ID
+      # @return [Array<Sawyer::Resource>] Array of traded pick objects
+      def draft_traded_picks(draft_id)
+        get "draft/#{draft_id}/traded_picks"
+      end
+    end
+  end
+end

--- a/lib/sleeper_ff/client/leagues.rb
+++ b/lib/sleeper_ff/client/leagues.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "sleeper_ff/league"
+require "sleeper_ff/draft"
+
 module SleeperFF
   class Client
     module Leagues
@@ -15,9 +18,12 @@ module SleeperFF
       # Get a specific league
       #
       # @param league_id [String] League ID
-      # @return [Sawyer::Resource] League information
+      # @return [SleeperFF::League] League object
       def league(league_id)
-        get "league/#{league_id}"
+        data = get "league/#{league_id}"
+        return nil if data.nil?
+
+        SleeperFF::League.new(data, self)
       end
 
       # Get all rosters in a league
@@ -34,6 +40,17 @@ module SleeperFF
       # @return [Array<Sawyer::Resource>] Array of user information
       def league_users(league_id)
         get "league/#{league_id}/users"
+      end
+
+      # Get all drafts for a league
+      #
+      # @param league_id [String] League ID
+      # @return [Array<SleeperFF::Draft>] Array of draft objects
+      def league_drafts(league_id)
+        data = get "league/#{league_id}/drafts"
+        return [] if data.nil?
+
+        data.map { |d| SleeperFF::Draft.new(d, self) }
       end
     end
   end

--- a/lib/sleeper_ff/draft.rb
+++ b/lib/sleeper_ff/draft.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module SleeperFF
+  class Draft
+    def initialize(data, client)
+      @data = data
+      @client = client
+    end
+
+    def picks
+      @client.draft_picks(@data.draft_id)
+    end
+
+    def traded_picks
+      @client.draft_traded_picks(@data.draft_id)
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      @data.respond_to?(method_name) || super
+    end
+
+    def method_missing(method_name, *args, &block)
+      if @data.respond_to?(method_name)
+        @data.send(method_name, *args, &block)
+      else
+        super
+      end
+    end
+  end
+end

--- a/lib/sleeper_ff/league.rb
+++ b/lib/sleeper_ff/league.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module SleeperFF
+  class League
+    def initialize(data, client)
+      @data = data
+      @client = client
+    end
+
+    def drafts
+      @client.league_drafts(@data.league_id)
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      @data.respond_to?(method_name) || super
+    end
+
+    def method_missing(method_name, *args, &block)
+      if @data.respond_to?(method_name)
+        @data.send(method_name, *args, &block)
+      else
+        super
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/SleeperFF_Client_Drafts/_draft/returns_draft_information.yml
+++ b/spec/fixtures/vcr_cassettes/SleeperFF_Client_Drafts/_draft/returns_draft_information.yml
@@ -1,0 +1,27 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sleeper.app/v1/draft/957401170459361281
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - SleeperFF Ruby Gem 0.1.0
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"type":"snake","status":"complete","sport":"nfl","settings":{"teams":12,"slots_wr":3,"slots_te":1,"slots_rb":2,"slots_qb":1,"slots_k":1,"slots_flex":1,"slots_def":1,"slots_bn":6,"rounds":15,"pick_timer":30},"season_type":"regular","season":"2023","metadata":{"scoring_type":"ppr","name":"body of elders","description":""},"last_picked":1693520000000,"last_message_time":1693520000000,"league_id":"957401170459361280","draft_order":{"782008200219205632":1,"987746245718417408":2},"draft_id":"957401170459361281","creators":null,"created":1693440000000,"slot_to_roster_id":{"1":1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8,"9":9,"10":10,"11":11,"12":12}}'
+  recorded_at: Wed, 02 Apr 2025 23:07:00 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/SleeperFF_Client_Drafts/_draft_picks/returns_all_picks_for_a_draft.yml
+++ b/spec/fixtures/vcr_cassettes/SleeperFF_Client_Drafts/_draft_picks/returns_all_picks_for_a_draft.yml
@@ -1,0 +1,27 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sleeper.app/v1/draft/957401170459361281/picks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - SleeperFF Ruby Gem 0.1.0
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '[{"player_id":"4046","picked_by":"782008200219205632","roster_id":1,"round":1,"draft_slot":1,"pick_no":1,"metadata":{"years_exp":"7","team":"KC","status":"Active","sport":"nfl","position":"RB","player_id":"4046","number":"27","news_updated":"1693400000000","last_name":"Hunt","injury_status":"","first_name":"Kareem","amount":"0"},"is_keeper":null,"draft_id":"957401170459361281"},{"player_id":"4035","picked_by":"987746245718417408","roster_id":2,"round":1,"draft_slot":2,"pick_no":2,"metadata":{"years_exp":"7","team":"PHI","status":"Active","sport":"nfl","position":"RB","player_id":"4035","number":"26","news_updated":"1693400000000","last_name":"Sanders","injury_status":"","first_name":"Miles","amount":"0"},"is_keeper":null,"draft_id":"957401170459361281"}]'
+  recorded_at: Wed, 02 Apr 2025 23:08:00 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/SleeperFF_Client_Drafts/_draft_traded_picks/returns_all_traded_picks_for_a_draft.yml
+++ b/spec/fixtures/vcr_cassettes/SleeperFF_Client_Drafts/_draft_traded_picks/returns_all_traded_picks_for_a_draft.yml
@@ -1,0 +1,27 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sleeper.app/v1/draft/957401170459361281/traded_picks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - SleeperFF Ruby Gem 0.1.0
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '[{"season":"2023","round":3,"roster_id":1,"previous_owner_id":3,"owner_id":5},{"season":"2023","round":5,"roster_id":7,"previous_owner_id":7,"owner_id":2}]'
+  recorded_at: Wed, 02 Apr 2025 23:09:00 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/SleeperFF_Client_Drafts/_user_drafts/returns_all_drafts_for_a_user.yml
+++ b/spec/fixtures/vcr_cassettes/SleeperFF_Client_Drafts/_user_drafts/returns_all_drafts_for_a_user.yml
@@ -1,0 +1,27 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sleeper.app/v1/user/782008200219205632/drafts/nfl/2023
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - SleeperFF Ruby Gem 0.1.0
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '[{"type":"snake","status":"complete","sport":"nfl","settings":{"teams":12,"slots_wr":3,"slots_te":1,"slots_rb":2,"slots_qb":1,"slots_k":1,"slots_flex":1,"slots_def":1,"slots_bn":6,"rounds":15,"pick_timer":30},"season_type":"regular","season":"2023","metadata":{"scoring_type":"ppr","name":"body of elders","description":""},"last_picked":1693520000000,"last_message_time":1693520000000,"league_id":"957401170459361280","draft_order":null,"draft_id":"957401170459361281","creators":null,"created":1693440000000,"slot_to_roster_id":{"1":1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8,"9":9,"10":10,"11":11,"12":12}}]'
+  recorded_at: Wed, 02 Apr 2025 23:06:00 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/SleeperFF_Client_Leagues/_league_drafts/returns_all_drafts_for_a_league.yml
+++ b/spec/fixtures/vcr_cassettes/SleeperFF_Client_Leagues/_league_drafts/returns_all_drafts_for_a_league.yml
@@ -1,0 +1,27 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sleeper.app/v1/league/957401170459361280/drafts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - SleeperFF Ruby Gem 0.1.0
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '[{"type":"snake","status":"complete","sport":"nfl","settings":{"teams":12,"slots_wr":3,"slots_te":1,"slots_rb":2,"slots_qb":1,"slots_k":1,"slots_flex":1,"slots_def":1,"slots_bn":6,"rounds":15,"pick_timer":30},"season_type":"regular","season":"2023","metadata":{"scoring_type":"ppr","name":"body of elders","description":""},"last_picked":1693520000000,"last_message_time":1693520000000,"league_id":"957401170459361280","draft_order":null,"draft_id":"957401170459361281","creators":null,"created":1693440000000,"slot_to_roster_id":{"1":1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8,"9":9,"10":10,"11":11,"12":12}}]'
+  recorded_at: Wed, 02 Apr 2025 23:05:00 GMT
+recorded_with: VCR 6.3.1

--- a/spec/sleeper_ff/client/drafts_spec.rb
+++ b/spec/sleeper_ff/client/drafts_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe SleeperFF::Client::Drafts do
+  let(:client) { SleeperFF.new }
+
+  describe "#user_drafts", :vcr do
+    it "returns all drafts for a user" do
+      drafts = client.user_drafts("782008200219205632", 2023)
+
+      expect(drafts).to be_an(Array)
+      expect(drafts.first).to be_a(SleeperFF::Draft)
+      expect(drafts.first).to respond_to(:draft_id)
+      expect(drafts.first).to respond_to(:league_id)
+      expect(drafts.first).to respond_to(:status)
+      expect(drafts.first).to respond_to(:picks)
+      expect(drafts.first).to respond_to(:traded_picks)
+    end
+  end
+
+  describe "#draft", :vcr do
+    it "returns draft information" do
+      draft = client.draft("957401170459361281")
+
+      expect(draft).to be_a(SleeperFF::Draft)
+      expect(draft.draft_id).to eq("957401170459361281")
+      expect(draft).to respond_to(:type)
+      expect(draft).to respond_to(:status)
+      expect(draft).to respond_to(:season)
+      expect(draft).to respond_to(:picks)
+      expect(draft).to respond_to(:traded_picks)
+    end
+  end
+
+  describe "#draft_picks", :vcr do
+    it "returns all picks for a draft" do
+      picks = client.draft_picks("957401170459361281")
+
+      expect(picks).to be_an(Array)
+      expect(picks.first).to respond_to(:player_id)
+      expect(picks.first).to respond_to(:picked_by)
+      expect(picks.first).to respond_to(:round)
+      expect(picks.first).to respond_to(:pick_no)
+    end
+  end
+
+  describe "#draft_traded_picks", :vcr do
+    it "returns all traded picks for a draft" do
+      traded_picks = client.draft_traded_picks("957401170459361281")
+
+      expect(traded_picks).to be_an(Array)
+      expect(traded_picks.first).to respond_to(:season)
+      expect(traded_picks.first).to respond_to(:round)
+      expect(traded_picks.first).to respond_to(:roster_id)
+      expect(traded_picks.first).to respond_to(:previous_owner_id)
+      expect(traded_picks.first).to respond_to(:owner_id)
+    end
+  end
+end

--- a/spec/sleeper_ff/client/leagues_spec.rb
+++ b/spec/sleeper_ff/client/leagues_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe SleeperFF::Client::Leagues do
         expect(league).to respond_to(:name)
         expect(league).to respond_to(:season)
         expect(league).to respond_to(:settings)
+        expect(league).to respond_to(:drafts)
       end
     end
 
@@ -55,6 +56,18 @@ RSpec.describe SleeperFF::Client::Leagues do
       expect(users).to be_an(Array)
       expect(users.first).to respond_to(:user_id)
       expect(users.first).to respond_to(:display_name)
+    end
+  end
+
+  describe "#league_drafts", :vcr do
+    it "returns all drafts for a league" do
+      drafts = client.league_drafts("957401170459361280")
+
+      expect(drafts).to be_an(Array)
+      expect(drafts.first).to respond_to(:draft_id)
+      expect(drafts.first).to respond_to(:league_id)
+      expect(drafts.first).to respond_to(:status)
+      expect(drafts.first).to respond_to(:type)
     end
   end
 end 


### PR DESCRIPTION
Implements all Sleeper draft API endpoints:
- GET /user/:id/drafts/nfl/:season via client.user_drafts
- GET /draft/:id via client.draft
- GET /draft/:id/picks via client.draft_picks / draft.picks
- GET /draft/:id/traded_picks via client.draft_traded_picks / draft.traded_picks
- GET /league/:id/drafts via client.league_drafts / league.drafts

Introduces SleeperFF::League and SleeperFF::Draft resource classes that wrap raw API data and expose lazy association methods (e.g. league.drafts, draft.picks) without additional HTTP calls until accessed.