### PR TITLE
Add trending_players endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,27 @@ traded_pick.previous_owner_id # => 3
 traded_pick.owner_id          # => 5
 ```
 
+### Players
+
+```ruby
+# Fetch all NFL players (response is ~5MB, cache locally and call sparingly)
+players = client.players
+
+# Get trending players by add or drop activity
+trending = client.trending_players("add")
+trending = client.trending_players("drop")
+
+# Optional parameters
+trending = client.trending_players("add", lookback_hours: 48, limit: 10)
+```
+
+```ruby
+# Trending player attributes
+trending.first.player_id  # => "4046"
+trending.first.count      # => 1842
+```
+
 More endpoints coming soon:
-- Players
 - Matchups
 - Transactions
 

--- a/lib/sleeper_ff/client/players.rb
+++ b/lib/sleeper_ff/client/players.rb
@@ -9,6 +9,16 @@ module SleeperFF
       def players
         get "players/nfl"
       end
+
+      # Get trending NFL players by add or drop activity
+      #
+      # @param type [String] "add" or "drop"
+      # @param lookback_hours [Integer] Hours to look back (default 24)
+      # @param limit [Integer] Number of results to return (default 25)
+      # @return [Array<Sawyer::Resource>] Array of trending player objects
+      def trending_players(type, lookback_hours: 24, limit: 25)
+        get "players/nfl/trending/#{type}", query: { lookback_hours: lookback_hours, limit: limit }
+      end
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/SleeperFF_Client_Players/_trending_players/returns_trending_players_by_add_activity.yml
+++ b/spec/fixtures/vcr_cassettes/SleeperFF_Client_Players/_trending_players/returns_trending_players_by_add_activity.yml
@@ -1,0 +1,27 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sleeper.app/v1/players/nfl/trending/add?limit=25&lookback_hours=24
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - SleeperFF Ruby Gem 0.1.0
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '[{"player_id":"4046","count":1842},{"player_id":"4035","count":1654},{"player_id":"2449","count":1423},{"player_id":"6794","count":1201},{"player_id":"5846","count":987}]'
+  recorded_at: Wed, 02 Apr 2025 23:15:00 GMT
+recorded_with: VCR 6.3.1

--- a/spec/sleeper_ff/client/players_spec.rb
+++ b/spec/sleeper_ff/client/players_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe SleeperFF::Client::Players do
+  let(:client) { SleeperFF.new }
+
+  describe "#trending_players", :vcr do
+    it "returns trending players by add activity" do
+      players = client.trending_players("add")
+
+      expect(players).to be_an(Array)
+      expect(players.first).to respond_to(:player_id)
+      expect(players.first).to respond_to(:count)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `trending_players` to the Players client, enabling lookups of the most-added or most-dropped NFL players on Sleeper.

- `client.trending_players("add")` / `client.trending_players("drop")`
- Optional `lookback_hours:` and `limit:` keyword arguments (defaults: 24h, 25 results)
- Spec with VCR cassette
- README updated with usage examples
