### PR TITLE
Add nfl_state endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,17 @@ trending.first.player_id  # => "4046"
 trending.first.count      # => 1842
 ```
 
-More endpoints coming soon:
-- Matchups
-- Transactions
+### Sport State
+
+```ruby
+# Get the current NFL season state
+state = client.nfl_state
+
+state.week          # => 1
+state.season        # => "2024"
+state.season_type   # => "regular"
+state.display_week  # => 1
+```
 
 ## Development
 

--- a/lib/sleeper_ff/client.rb
+++ b/lib/sleeper_ff/client.rb
@@ -6,6 +6,7 @@ require "sleeper_ff/client/users"
 require "sleeper_ff/client/leagues"
 require "sleeper_ff/client/drafts"
 require "sleeper_ff/client/players"
+require "sleeper_ff/client/sport"
 
 module SleeperFF
   class Client
@@ -14,6 +15,7 @@ module SleeperFF
     include SleeperFF::Client::Leagues
     include SleeperFF::Client::Drafts
     include SleeperFF::Client::Players
+    include SleeperFF::Client::Sport
 
     # Header keys that can be passed in options hash
     CONVENIENCE_HEADERS = Set.new([:accept, :content_type])

--- a/lib/sleeper_ff/client/sport.rb
+++ b/lib/sleeper_ff/client/sport.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module SleeperFF
+  class Client
+    module Sport
+      # Get the current state of an NFL season
+      #
+      # @return [Sawyer::Resource] Current NFL state including week, season, and season type
+      def nfl_state
+        get "state/nfl"
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/SleeperFF_Client_Sport/_nfl_state/returns_the_current_nfl_state.yml
+++ b/spec/fixtures/vcr_cassettes/SleeperFF_Client_Sport/_nfl_state/returns_the_current_nfl_state.yml
@@ -1,0 +1,27 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sleeper.app/v1/state/nfl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - SleeperFF Ruby Gem 0.1.0
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"week":1,"season_type":"regular","season":"2024","previous_season":"2023","leg":1,"league_season":"2024","league_create_season":"2024","display_week":1}'
+  recorded_at: Wed, 02 Apr 2025 23:16:00 GMT
+recorded_with: VCR 6.3.1

--- a/spec/sleeper_ff/client/sport_spec.rb
+++ b/spec/sleeper_ff/client/sport_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe SleeperFF::Client::Sport do
+  let(:client) { SleeperFF.new }
+
+  describe "#nfl_state", :vcr do
+    it "returns the current nfl state" do
+      state = client.nfl_state
+
+      expect(state).not_to be_nil
+      expect(state).to respond_to(:week)
+      expect(state).to respond_to(:season)
+      expect(state).to respond_to(:season_type)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `client.nfl_state` to fetch the current NFL season state, including the current week, season, and season type.

- New `SleeperFF::Client::Sport` module with `nfl_state` method
- Spec with VCR cassette
- README updated with usage examples
