### PR TITLE
Fix StandardRB failures

### DIFF
--- a/.claude/commands/pr-description.md
+++ b/.claude/commands/pr-description.md
@@ -1,0 +1,11 @@
+Generate a concise PR description based on the commits in the current branch and copy it to the clipboard using pbcopy.
+
+Steps:
+1. Run `git log main..HEAD --oneline` to see what commits are in this branch
+2. Write a brief PR description in this format:
+   - A `## Summary` heading
+   - 1-2 sentence overview of what the PR does
+   - A bullet list of the specific changes (endpoints added, classes introduced, etc.)
+   - Only include what was changed in THIS branch — do not reference work from other branches
+3. Copy the description to the clipboard using: `echo '<markdown>' | pbcopy`
+4. Display the description to the user

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,10 @@
       "Bash(git log*)",
       "Bash(mkdir -p*)",
       "Bash(pbcopy*)",
-      "Bash(bundle exec rake release)"
+      "Bash(bundle exec rake release)",
+      "Bash(bundle exec rake standard:fix 2>&1)",
+      "Bash(bundle exec rake standard 2>&1)",
+      "Bash(bundle exec rake 2>&1 | tail*)"
     ]
   }
 }

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,3 +1,5 @@
 # For available configuration options, see:
 #   https://github.com/standardrb/standard
 ruby_version: 3.0
+ignore:
+  - .claude/**/*

--- a/lib/sleeper_ff/client.rb
+++ b/lib/sleeper_ff/client.rb
@@ -40,14 +40,14 @@ module SleeperFF
 
     def request(method, path, data, options = {})
       if data.is_a?(Hash)
-        options[:query]   = data.delete(:query) || {}
+        options[:query] = data.delete(:query) || {}
         options[:headers] = data.delete(:headers) || {}
-        if accept = data.delete(:accept)
+        if (accept = data.delete(:accept))
           options[:headers][:accept] = accept
         end
       end
 
-      @last_response = response = agent.call(method, URI::Parser.new.escape(path.to_s), data, options)
+      @last_response = response = agent.call(method, URI::DEFAULT_PARSER.escape(path.to_s), data, options)
       response.data
     end
 
@@ -58,4 +58,4 @@ module SleeperFF
       end
     end
   end
-end 
+end

--- a/lib/sleeper_ff/client/leagues.rb
+++ b/lib/sleeper_ff/client/leagues.rb
@@ -96,4 +96,4 @@ module SleeperFF
       end
     end
   end
-end 
+end

--- a/lib/sleeper_ff/client/players.rb
+++ b/lib/sleeper_ff/client/players.rb
@@ -17,7 +17,7 @@ module SleeperFF
       # @param limit [Integer] Number of results to return (default 25)
       # @return [Array<Sawyer::Resource>] Array of trending player objects
       def trending_players(type, lookback_hours: 24, limit: 25)
-        get "players/nfl/trending/#{type}", query: { lookback_hours: lookback_hours, limit: limit }
+        get "players/nfl/trending/#{type}", query: {lookback_hours: lookback_hours, limit: limit}
       end
     end
   end

--- a/lib/sleeper_ff/client/users.rb
+++ b/lib/sleeper_ff/client/users.rb
@@ -12,4 +12,4 @@ module SleeperFF
       end
     end
   end
-end 
+end

--- a/lib/sleeper_ff/configurable.rb
+++ b/lib/sleeper_ff/configurable.rb
@@ -27,4 +27,4 @@ module SleeperFF
       self
     end
   end
-end 
+end

--- a/lib/sleeper_ff/default.rb
+++ b/lib/sleeper_ff/default.rb
@@ -2,9 +2,9 @@
 
 module SleeperFF
   module Default
-    API_ENDPOINT = "https://api.sleeper.app/v1".freeze
+    API_ENDPOINT = "https://api.sleeper.app/v1"
     USER_AGENT = "SleeperFF Ruby Gem #{SleeperFF::VERSION}".freeze
-    MEDIA_TYPE = "application/json".freeze
+    MEDIA_TYPE = "application/json"
 
     class << self
       def api_endpoint
@@ -20,4 +20,4 @@ module SleeperFF
       end
     end
   end
-end 
+end

--- a/lib/sleeper_ff/error.rb
+++ b/lib/sleeper_ff/error.rb
@@ -27,4 +27,4 @@ module SleeperFF
 
   # Raised when Sleeper returns a 503 HTTP status code
   class ServiceUnavailable < Error; end
-end 
+end

--- a/spec/sleeper_ff/client/leagues_spec.rb
+++ b/spec/sleeper_ff/client/leagues_spec.rb
@@ -131,4 +131,4 @@ RSpec.describe SleeperFF::Client::Leagues do
       expect(drafts.first).to respond_to(:type)
     end
   end
-end 
+end

--- a/spec/sleeper_ff/client/users_spec.rb
+++ b/spec/sleeper_ff/client/users_spec.rb
@@ -24,4 +24,4 @@ RSpec.describe SleeperFF::Client::Users do
       end
     end
   end
-end 
+end


### PR DESCRIPTION
## Summary

Fixes the StandardRB linting failures from CI and prevents future recurrence.

- Fix StandardRB violations across `client.rb`, `leagues.rb`, `players.rb`, `users.rb`, and related files
- Add `.claude/**/*` to `.standard.yml` ignore list so the linter no longer deletes Claude config files
- Add `/pr-description` slash command to `.claude/commands/`
